### PR TITLE
Issue #21: fix incorrect remaining bolus time.

### DIFF
--- a/app/src/main/java/com/hypodiabetic/happ/Objects/Treatments.java
+++ b/app/src/main/java/com/hypodiabetic/happ/Objects/Treatments.java
@@ -126,10 +126,7 @@ public class Treatments extends Model{
 
                 if (iobDetails.optDouble("iobContrib", 0) > 0) {                                    //Still active Insulin
                     String isLeft = tools.formatDisplayInsulin(iobDetails.optDouble("iobContrib", 0), 2);
-                    Date now = new Date();
-                    Long calc = now.getTime() + (iobDetails.optLong("minsLeft", 0) * 60000);
-                    Date finish = new Date(calc);
-                    String timeLeft = tools.formatDisplayTimeLeft(new Date(), finish);
+                    String timeLeft = calculateRemainingBolusTime(profile.dia);
                     return isLeft + " " + timeLeft + " remaining";
                 } else {                                                                            //Not active
                     return "Not Active";
@@ -156,5 +153,10 @@ public class Treatments extends Model{
                 return "ERROR: unknown treatment type";
         }
 
+    }
+
+    private String calculateRemainingBolusTime(Double dia) {
+        Long endTime = this.datetime + (long) (dia * 60 * 60000);
+        return tools.formatDisplayTimeLeft(new Date(), new Date(endTime));
     }
 }

--- a/app/src/main/java/com/hypodiabetic/happ/integration/openaps/IOB.java
+++ b/app/src/main/java/com/hypodiabetic/happ/integration/openaps/IOB.java
@@ -68,7 +68,7 @@ public class IOB {
         if (treatment.type.equals("Insulin") ) {                               //Im only ever passing Insulin, but anyway whatever
 
             Date bolusTime = new Date(treatment.datetime);                                          //Time the Insulin was taken
-            Double minAgo = (double)(time.getTime() - bolusTime.getTime()) /1000/60;                //Age in Mins of the treatment
+            Double minAgo = diaratio * (time.getTime() - bolusTime.getTime()) /1000/60;             //Age in Mins of the treatment
             Double iobContrib = 0D;
             Double activityContrib = 0D;
 
@@ -89,19 +89,13 @@ public class IOB {
                 returnValue.put("iobContrib", iobContrib);
                 if (activityContrib.isInfinite()) activityContrib = 0D;                             //*HAPP added*
                 returnValue.put("activityContrib", activityContrib);
-                returnValue.put("minsLeft", end-minAgo);                                            //mins left *HAPP added*
-                return returnValue;
-
             } catch (JSONException e) {
                 Crashlytics.logException(e);
                 e.printStackTrace();
-                return returnValue;
             }
+        }
 
-        }
-        else {
-            return returnValue;
-        }
+        return returnValue;
     }
 
     //gets the total IOB from multiple Treatments


### PR DESCRIPTION
diabetic.happ.integration.openaps.IOB#iobCalc used a hardcoded value,
rather than the one configured and passed to the method (parm dia).
