### PR TITLE
Remove the single-value ISF menu option.

### DIFF
--- a/app/src/main/res/xml/pref_aps.xml
+++ b/app/src/main/res/xml/pref_aps.xml
@@ -68,11 +68,6 @@
                 android:key="aps_profiles"
                 android:title="Profiles">
 
-                <EditTextPreference
-                    android:title="Insulin Sensitivity Factor"
-                    android:key="isf_profile"
-                    android:summary=""/>
-
                 <PreferenceScreen
                     android:title="Insulin Sensitivity Factor"
                     android:key="button_aps_isf_profile"


### PR DESCRIPTION
Superseeded by the ISF profile editor.
